### PR TITLE
fix: exclude communication policy from private link routing

### DIFF
--- a/internal/iruntime/private_link_policy.go
+++ b/internal/iruntime/private_link_policy.go
@@ -17,9 +17,31 @@ type PrivateLinkPolicy struct{}
 // Admin APIs are excluded intentionally since they are blocked through workspace PE
 var workspaceIdRegex = regexp.MustCompile(`v1/workspaces/([0-9a-fA-F\-]{36})(/.*)?$`)
 
+const (
+	communicationPolicyPath   = "/networking/communicationPolicy"
+	communicationPoliciesPath = "/networking/communicationPolicies"
+)
+
 // NewPrivateLinkPolicy creates a new instance of PrivateLinkPolicy
 func NewPrivateLinkPolicy() *PrivateLinkPolicy {
 	return &PrivateLinkPolicy{}
+}
+
+func workspaceIDFromPath(path string) (string, bool) {
+	matches := workspaceIdRegex.FindStringSubmatch(path)
+	if len(matches) <= 1 {
+		return "", false
+	}
+
+	if isCommunicationPolicyPath(matches[2]) {
+		return "", false
+	}
+
+	return matches[1], true
+}
+
+func isCommunicationPolicyPath(path string) bool {
+	return path == communicationPolicyPath || path == communicationPoliciesPath
 }
 
 // Do implements the policy.Policy interface
@@ -28,10 +50,9 @@ func (p *PrivateLinkPolicy) Do(req *policy.Request) (*http.Response, error) {
 	originalURL := req.Raw().URL
 
 	// Check if the URI matches the pattern
-	matches := workspaceIdRegex.FindStringSubmatch(originalURL.Path)
-	if len(matches) > 1 {
+	workspaceIDStr, ok := workspaceIDFromPath(originalURL.Path)
+	if ok {
 		// Extract the workspaceId as a string without the dashes
-		workspaceIDStr := matches[1]
 		workspaceID, err := uuid.Parse(workspaceIDStr)
 		if err != nil {
 			return req.Next()


### PR DESCRIPTION
Communication policy APIs must continue using the standard Fabric endpoint when workspace private links are enabled.

## Summary

- exclude both `/networking/communicationPolicy` and `/networking/communicationPolicies` from workspace FQDN rewriting
- isolate workspace path extraction and endpoint exclusion into readable helpers
- preserve existing private-link routing for all other workspace APIs

## Validation

- `go test ./internal/iruntime`