### PR TITLE
fix(privatelink): exclude communicationPolicy sub-paths from host rewriting

### DIFF
--- a/internal/iruntime/private_link_policy.go
+++ b/internal/iruntime/private_link_policy.go
@@ -39,8 +39,13 @@ func workspaceIDFromPath(path string) (string, bool) {
 	return matches[1], true
 }
 
+// isCommunicationPolicyPath reports whether the path is the communication policy
+// endpoint itself or any endpoint nested under it.
 func isCommunicationPolicyPath(path string) bool {
-	return strings.EqualFold(path, communicationPolicyPath)
+	normalized := strings.ToLower(path)
+	prefix := strings.ToLower(communicationPolicyPath)
+
+	return normalized == prefix || strings.HasPrefix(normalized, prefix+"/")
 }
 
 // Do implements the policy.Policy interface

--- a/internal/iruntime/private_link_policy_test.go
+++ b/internal/iruntime/private_link_policy_test.go
@@ -57,10 +57,46 @@ func TestWorkspaceIDFromPath(t *testing.T) {
 			expectedOK: false,
 		},
 		{
-			name:       "communicationPolicy with sub-path is not excluded",
+			name:       "communicationPolicy with sub-path is excluded",
 			path:       "/v1/workspaces/12345678-1234-1234-1234-123456789abc/networking/communicationPolicy/settings",
-			expectedID: "12345678-1234-1234-1234-123456789abc",
-			expectedOK: true,
+			expectedID: "",
+			expectedOK: false,
+		},
+		{
+			name:       "communicationPolicy outbound connections excluded",
+			path:       "/v1/workspaces/12345678-1234-1234-1234-123456789abc/networking/communicationPolicy/outbound/connections",
+			expectedID: "",
+			expectedOK: false,
+		},
+		{
+			name:       "communicationPolicy outbound gateways excluded",
+			path:       "/v1/workspaces/12345678-1234-1234-1234-123456789abc/networking/communicationPolicy/outbound/gateways",
+			expectedID: "",
+			expectedOK: false,
+		},
+		{
+			name:       "communicationPolicy outbound git excluded",
+			path:       "/v1/workspaces/12345678-1234-1234-1234-123456789abc/networking/communicationPolicy/outbound/git",
+			expectedID: "",
+			expectedOK: false,
+		},
+		{
+			name:       "communicationPolicy inbound firewall excluded",
+			path:       "/v1/workspaces/12345678-1234-1234-1234-123456789abc/networking/communicationPolicy/inbound/firewall",
+			expectedID: "",
+			expectedOK: false,
+		},
+		{
+			name:       "communicationPolicy inbound azureResources excluded",
+			path:       "/v1/workspaces/12345678-1234-1234-1234-123456789abc/networking/communicationPolicy/inbound/azureResources",
+			expectedID: "",
+			expectedOK: false,
+		},
+		{
+			name:       "communicationPolicy inbound externalDataShares excluded",
+			path:       "/v1/workspaces/12345678-1234-1234-1234-123456789abc/networking/communicationPolicy/inbound/externalDataShares",
+			expectedID: "",
+			expectedOK: false,
 		},
 
 		// --- non-matching paths ---
@@ -139,9 +175,10 @@ func TestIsCommunicationPolicyPath(t *testing.T) {
 		{name: "exact communicationPolicy", path: "/networking/communicationPolicy", expected: true},
 		{name: "unrelated path", path: "/items", expected: false},
 		{name: "empty string", path: "", expected: false},
-		{name: "extra segment after policy", path: "/networking/communicationPolicy/extra", expected: false},
-		{name: "trailing slash", path: "/networking/communicationPolicy/", expected: false},
+		{name: "extra segment after policy", path: "/networking/communicationPolicy/extra", expected: true},
+		{name: "trailing slash", path: "/networking/communicationPolicy/", expected: true},
 		{name: "different casing", path: "/networking/CommunicationPolicy", expected: true},
+		{name: "different casing with sub-path", path: "/networking/CommunicationPolicy/Inbound/Firewall", expected: true},
 		{name: "suffix match (policyExtra)", path: "/networking/communicationPolicyExtra", expected: false},
 	}
 


### PR DESCRIPTION
## Why

`PrivateLinkPolicy` rewrites request hosts to the workspace-level private link prefix, but workspace communication policy APIs must not be redirected through the workspace private endpoint. The exclusion only matched the exact path `/networking/communicationPolicy`, so every sub-resource under it (`/inbound/firewall`, `/outbound/git`, `/inbound/azureResources`, `/inbound/externalDataShares`, `/outbound/connections`, `/outbound/gateways`) was still being rewritten.

## What changed

`isCommunicationPolicyPath` now excludes the exact path plus anything beneath it, effectively `/networking/communicationPolicy/*`. Matching stays case-insensitive, and a trailing slash is treated as part of the prefix.

The check deliberately uses a `communicationPolicy/` prefix comparison rather than a plain `strings.HasPrefix` on the bare constant, so sibling paths such as `/networking/communicationPolicyExtra` are still not excluded.

## Tests

Updated `private_link_policy_test.go` cases for the new behavior (sub-path and trailing slash now excluded, plus a mixed-casing sub-path case). `go test ./internal/iruntime/...` passes.